### PR TITLE
Fixing evaluation errors while using mypy-types

### DIFF
--- a/nixops_gcp/backends/options.py
+++ b/nixops_gcp/backends/options.py
@@ -58,4 +58,4 @@ class GceOptions(ResourceOptions):
     serviceAccount: str
     subnet: Optional[str]
     tags: Sequence[str]
-    fileSystems: Mapping[str, FilesystemsOptions]
+    fileSystems: Optional[Mapping[str, FilesystemsOptions]]

--- a/nixops_gcp/gcp_common.py
+++ b/nixops_gcp/gcp_common.py
@@ -36,7 +36,12 @@ class ResourceDefinition(nixops.resources.ResourceDefinition):
     def __init__(self, name, config):
         super().__init__(name, config)
 
-        res_name = self.config.name
+        res_name: str
+        if hasattr(self.config, "gce") and hasattr(self.config.gce, "machineName"):
+            res_name = self.config.gce.machineName
+        else:
+            res_name = self.config.name
+
         if (
             len(res_name) > 63
             or re.match("[a-z]([-a-z0-9]{0,61}[a-z0-9])?$", res_name) is None
@@ -49,9 +54,18 @@ class ResourceDefinition(nixops.resources.ResourceDefinition):
                 "except the last character, which cannot be a dash.".format(res_name)
             )
 
-        self.project = self.config.project
-        self.service_account = self.config.serviceAccount
-        self.access_key_path = self.config.accessKey
+        if hasattr(self.config, "gce") and hasattr(self.config.gce, "project"):
+            self.project = self.config.gce.project
+        else:
+            self.project = self.config.project
+        if hasattr(self.config, "gce") and hasattr(self.config.gce, "serviceAccount"):
+            self.service_account = self.config.gce.serviceAccount
+        else:
+            self.service_account = self.config.serviceAccount
+        if hasattr(self.config, "gce") and hasattr(self.config.gce, "accessKey"):
+            self.access_key_path = self.config.gce.accessKey
+        else:
+            self.access_key_path = self.config.accessKey
 
 
 class ResourceState(nixops.resources.ResourceState):

--- a/nixops_gcp/resources/gce_disk.py
+++ b/nixops_gcp/resources/gce_disk.py
@@ -61,7 +61,7 @@ class GCEDiskState(ResourceState):
         ResourceState.__init__(self, depl, name, id)
 
     def show_type(self):
-        s = super().show_type
+        s = super().show_type()
         if self.state == self.UP:
             s = "{0} [{1}; {2} GiB]".format(s, self.region, self.size)
         return s

--- a/nixops_gcp/resources/gce_route.py
+++ b/nixops_gcp/resources/gce_route.py
@@ -7,13 +7,13 @@ import libcloud.common.google
 from nixops import backends
 from nixops.util import attr_property
 from nixops_gcp.gcp_common import ResourceDefinition, ResourceState
-from .types.gce_routes import GceRoutesOptions
+from .types.gce_route import GceRouteOptions
 
 
 class GCERouteDefinition(ResourceDefinition):
     """Definition of a GCE Route"""
 
-    config: GceRoutesOptions
+    config: GceRouteOptions
 
     @classmethod
     def get_type(cls):

--- a/nixops_gcp/resources/types/gce_images.py
+++ b/nixops_gcp/resources/types/gce_images.py
@@ -1,5 +1,0 @@
-from nixops.resources import ResourceOptions
-
-
-class GceImagesOptions(ResourceOptions):
-    pass

--- a/nixops_gcp/resources/types/gce_route.py
+++ b/nixops_gcp/resources/types/gce_route.py
@@ -4,7 +4,7 @@ from typing import Union
 from typing import Optional
 
 
-class GceRoutesOptions(ResourceOptions):
+class GceRouteOptions(ResourceOptions):
     accessKey: str
     description: Optional[str]
     destination: Optional[str]

--- a/poetry.lock
+++ b/poetry.lock
@@ -120,14 +120,14 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.6.0"
+version = "1.6.1"
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "importlib-resources"]
+testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
 
 [[package]]
 category = "dev"
@@ -168,7 +168,7 @@ typeguard = "^2.7.1"
 typing-extensions = "^3.7.4"
 
 [package.source]
-reference = "68aa76845573a8e6613286a730f0a2c9e394af97"
+reference = "0fc0434250e9855ee9239bc48d87e7a31ed433e8"
 type = "git"
 url = "https://github.com/NixOS/nixops.git"
 [[package]]
@@ -275,7 +275,7 @@ description = "Run-time type checker for Python"
 name = "typeguard"
 optional = false
 python-versions = ">=3.5.2"
-version = "2.7.1"
+version = "2.8.0"
 
 [package.extras]
 doc = ["sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
@@ -404,8 +404,8 @@ idna = [
     {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
-    {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
+    {file = "importlib_metadata-1.6.1-py2.py3-none-any.whl", hash = "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"},
+    {file = "importlib_metadata-1.6.1.tar.gz", hash = "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545"},
 ]
 mypy = [
     {file = "mypy-0.770-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:a34b577cdf6313bf24755f7a0e3f3c326d5c1f4fe7422d1d06498eb25ad0c600"},
@@ -509,8 +509,8 @@ typed-ast = [
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
 ]
 typeguard = [
-    {file = "typeguard-2.7.1-py3-none-any.whl", hash = "sha256:1d3710251d3d3d6c64e0c49f45edec2e88ddc386a51e89c3ec0703efeb8b3b81"},
-    {file = "typeguard-2.7.1.tar.gz", hash = "sha256:2d545c71e9439c21bcd7c28f5f55b3606e6106f7031ab58375656a1aed483ef2"},
+    {file = "typeguard-2.8.0-py3-none-any.whl", hash = "sha256:9d77078393507d733d13ceff9eb75ff298f968d73eb73fb812f748fdc6c55c1d"},
+    {file = "typeguard-2.8.0.tar.gz", hash = "sha256:e718f493d805d596cba238a61aa83b874530a333783ca9d597fe5bf27143f042"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.2-py2-none-any.whl", hash = "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"},


### PR DESCRIPTION
After meeting with @adisbladis we worked together to work around all evaluation errors

- Adding config as GCEMachinesOptions in GCEDefinition
- Updating GCEDefinition attributes by specifying gce as parent attribute
- adding the scheduling options
- Correcting the instanceServiceAccount attrs ( email and scopes )
- nixosRelease as attr
- Using disk name while attaching a GCE Disk
- fileSystems backend option made optional
- Finally, adding a temporary check over gcp_common options

Additionally added :
- Fix type of GCE disk
- gce_routes -> gce_route renaming
- Removal of GceImagesOptions