### PR TITLE
Network and image fixes

### DIFF
--- a/examples/rmq-gce.nix
+++ b/examples/rmq-gce.nix
@@ -114,7 +114,6 @@ let
         };
 
         resources.gceNetworks."${prefix}net" = credentials // {
-            addressRange = "192.168.0.0/16";
             firewall = {
                 allow-rmq = {
                     targetTags = ["rmq-node"];

--- a/nixops_gcp/backends/options.py
+++ b/nixops_gcp/backends/options.py
@@ -12,7 +12,7 @@ from typing import (
 
 
 class ImageOptions(ResourceOptions):
-    name: Optional[Union[str, ResourceEval]]
+    name: Optional[str]
     family: Optional[str]
     project: Optional[str]
 

--- a/nixops_gcp/nix/gce-disk.nix
+++ b/nixops_gcp/nix/gce-disk.nix
@@ -50,7 +50,7 @@ in
     image = mkOption {
       default  = {};
       example = { name = null; family = "super-family"; project = "operations"; };
-      type = with types; (submodule imageOptions);
+      type = with types; either (resource "gce-image") (submodule imageOptions);
       description = ''
         The image, image family or image-resource from which to create the GCE disk.
         If not specified, an empty disk is created. Changing the
@@ -69,7 +69,7 @@ in
 
   };
 
-  config = 
+  config =
     (mkAssert ( (config.snapshot == null) || ((config.image.name == null) && (config.image.family == null)))
               "Disk can not be created from both a snapshot, image name or image family at once"
     (mkAssert ( (config.size != null) || (config.snapshot != null) || (config.image.name != null)

--- a/nixops_gcp/nix/gce-network.nix
+++ b/nixops_gcp/nix/gce-network.nix
@@ -78,16 +78,6 @@ in
       description = "Description of the GCE Network. This is the <literal>Name</literal> tag of the network.";
     };
 
-    addressRange = mkOption {
-      example = "192.168.0.0/16";
-      type = types.str;
-      description = ''
-        The range of internal addresses that are legal on this network.
-        This range is a <link xlink:href="http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing">CIDR</link>
-        specification.
-      '';
-    };
-
     firewall = mkOption {
         default = {
           allow-ssh.allowed.tcp = [ 22 ];

--- a/nixops_gcp/nix/gce.nix
+++ b/nixops_gcp/nix/gce.nix
@@ -288,6 +288,7 @@ in
         default = null;
         example = "resources.gceNetworks.verySecureNetwork";
         type = types.nullOr ( types.either types.str (resource "gce-network") );
+        apply = x: if builtins.elem (builtins.typeOf x) [ "string" "null" ] then x else x.name;
         description = ''
           The GCE Network to make the instance a part of. Can be either
           a gceNetworks resource or a name of a network not managed by NixOps.

--- a/nixops_gcp/nix/gce.nix
+++ b/nixops_gcp/nix/gce.nix
@@ -353,7 +353,17 @@ in
           # project = "nixos-org";
           project = "predictix-operations";
         };
-        type = with types; (submodule imageOptions);
+        type = with types; (either (resource "gce-image") (submodule imageOptions));
+
+        apply = x:
+          if (x._type or null) == "gce-image" then {
+            name = x._name;
+            family = null;
+            inherit (x) project;
+          }
+          else
+            x;
+
         description = ''
           Bootstrap image out of which the root disks
           of the machines will be created.

--- a/nixops_gcp/nix/gce.nix
+++ b/nixops_gcp/nix/gce.nix
@@ -60,6 +60,7 @@ let
         default = null;
         example = "resources.gceDisks.exampleDisk";
         type = types.nullOr ( types.either types.str (resource "gce-disk") );
+        apply = x: if x == null || (builtins.isString x) then x else x.name;
         description = ''
           GCE Disk resource or name of a disk not managed by NixOps to be mounted.
         '';
@@ -78,7 +79,7 @@ let
 
       image = mkOption {
         default  = {};
-        type = with types; (nullOr (submodule imageOptions));
+        type = with types; nullOr (either (resource "gce-image") (submodule imageOptions));
         description = ''
           The image, image family or image-resource from which to create the GCE disk.
           If not specified, an empty disk is created. Changing the
@@ -355,16 +356,6 @@ in
           project = "predictix-operations";
         };
         type = with types; (either (resource "gce-image") (submodule imageOptions));
-
-        apply = x:
-          if (x._type or null) == "gce-image" then {
-            name = x._name;
-            family = null;
-            inherit (x) project;
-          }
-          else
-            x;
-
         description = ''
           Bootstrap image out of which the root disks
           of the machines will be created.

--- a/nixops_gcp/nix/image-options.nix
+++ b/nixops_gcp/nix/image-options.nix
@@ -7,7 +7,7 @@ with lib;
     name = mkOption {
       default = null;
       example = "image-2cfda297";
-      type = types.nullOr (types.either types.str (resource "gce-image"));
+      type = types.nullOr types.str;
       description = ''
         Name of an existent image or image-resource to be used.
         Must specify the project if the image is defined as public.

--- a/nixops_gcp/resources/types/gce_network.py
+++ b/nixops_gcp/resources/types/gce_network.py
@@ -14,7 +14,6 @@ class FirewallOptions(ResourceOptions):
 
 class GceNetworkOptions(ResourceOptions):
     accessKey: str
-    addressRange: str
     firewall: Mapping[str, FirewallOptions]
     name: str
     project: str


### PR DESCRIPTION
Fix the following issues:

- `bootstrapImage` doesn't allow a `gce-image` resource to be specified
- `network` allows a `gce-network` resource to be specified, but it's not handled
- `gce-network` resources are deployed as legacy networks, which are no longer supported