### PR TITLE
Example for custom bootstrap image

### DIFF
--- a/examples/custom-image.nix
+++ b/examples/custom-image.nix
@@ -1,0 +1,43 @@
+{
+  gcpProject                     # (required) GCP project to deploy to
+, serviceAccount                 # (required) GCP service account email
+, accessKey                      # (required) path to GCP access key
+, region ? "us-east1-b"          # GCE region
+, instanceType ? "n1-standard-2" # Default GCE VM (instance) type
+, subnet ? ""
+, volumeSize ? 50                # Default volume size
+, description ? "Deploy from custom image"
+, ...
+}:
+{
+  network.description = description;
+
+  resources.gceImages.custom-image = 
+    { config, resources, lib, name, pkgs, ...}:
+    {
+      inherit serviceAccount;
+      project = gcpProject;
+      accessKey = builtins.readFile accessKey;
+      sourceUri = "gs://nixos-cloud-images/nixos-image-18.09.1228.a4c4cbb613c-x86_64-linux.raw.tar.gz";
+      description = "custom 18.09 image";
+    };
+
+
+  custom-machine =
+    { config, resources, lib, name, uuid, pkgs, ...}:
+    let
+      machineName = "${config.deployment.name}-" + "${name}-" + builtins.substring 2 6 "${uuid}";
+    in
+    rec {
+      deployment.targetEnv = "gce";
+      deployment.gce = {
+        inherit region subnet serviceAccount machineName;
+        project = gcpProject;
+        instanceType = lib.mkDefault instanceType;
+        accessKey = builtins.readFile accessKey;
+        rootDiskSize = 10;
+        bootstrapImage = resources.gceImages.custom-image;
+      };
+   };
+
+}

--- a/examples/custom-image.nix
+++ b/examples/custom-image.nix
@@ -6,14 +6,12 @@
 , instanceType ? "n1-standard-2" # Default GCE VM (instance) type
 , subnet ? ""
 , volumeSize ? 50                # Default volume size
-, description ? "Deploy from custom image"
 , ...
 }:
 {
-  network.description = description;
+  network.description = "Deploy from custom image";
 
   resources.gceImages.custom-image = 
-    { config, resources, lib, name, pkgs, ...}:
     {
       inherit serviceAccount;
       project = gcpProject;
@@ -23,15 +21,12 @@
     };
 
 
-  custom-machine =
-    { config, resources, lib, name, uuid, pkgs, ...}:
-    let
-      machineName = "${config.deployment.name}-" + "${name}-" + builtins.substring 2 6 "${uuid}";
-    in
-    rec {
+  machine =
+    { resources, lib, ... }:
+    {
       deployment.targetEnv = "gce";
       deployment.gce = {
-        inherit region subnet serviceAccount machineName;
+        inherit region subnet serviceAccount;
         project = gcpProject;
         instanceType = lib.mkDefault instanceType;
         accessKey = builtins.readFile accessKey;

--- a/examples/machine-with-disk.nix
+++ b/examples/machine-with-disk.nix
@@ -7,21 +7,17 @@
 , subnet ? ""
 , volumeSize ? 50                # Default volume size
 , labels ? {}
-, description ? ""
 , ...
 }:
 {
-  network.description = description;
+  network.description = "Machine + Disk example";
 
   defaults =
-    { config, resources, lib, name, uuid, pkgs, ...}:
-    let
-      machineName = "${config.deployment.name}-" + "${name}-" + builtins.substring 2 6 "${uuid}";
-    in
-    rec {
+    { resources, lib, uuid, ... }:
+    {
       deployment.targetEnv = "gce";
       deployment.gce = {
-        inherit region subnet serviceAccount machineName;
+        inherit region subnet serviceAccount;
         project = gcpProject;
         labels = labels;
         instanceType = lib.mkDefault instanceType;
@@ -43,7 +39,7 @@
 
   # GCE Disk for Frontend
   resources.gceDisks.frontend-volume =
-    { resources, lib, ...}:
+    { resources, lib, ... }:
     let
       namespace = resources.machines.frontend.deployment.gce;
     in

--- a/examples/rmq-gce.nix
+++ b/examples/rmq-gce.nix
@@ -38,7 +38,7 @@ let
     credentials = {
         project = "logicblox-dev";
         serviceAccount = "572772620792-gecnc5v4ks9e6s13tociphd1p9ct6emr@developer.gserviceaccount.com";
-        accessKey = "/home/freedom/nixos/phreedom/key.pem";
+        accessKey = builtins.readFile "/home/freedom/nixos/phreedom/key.pem";
     };
 
     mkRabbitMQCluster = { prefix ? "rmq-", size, user ? "rmq", password, cookie, credentials, ipAddress ? null, region, extraConfig ? {}, extraGceConfig ? {} }:

--- a/examples/trivial-gce.nix
+++ b/examples/trivial-gce.nix
@@ -5,7 +5,7 @@
         # credentials
         project = "...";
         serviceAccount = "...@developer.gserviceaccount.com";
-        accessKey = "/path/to/your.pem";
+        accessKey = builtins.readFile "/path/to/your.pem";
 
         # instance properties
         region = "europe-west1-b";


### PR DESCRIPTION
Fix the support for custom bootstrap image

```
machine = {
  deployment.gce = {
    bootstrapImage.name = resources.gceImages.custom-image;
  };
}
```

Ref to https://github.com/nix-community/nixops-gce/pull/12

@talyz Hope this makes sense, I believe this was the consensus as discussed per https://github.com/nix-community/nixops-gce/pull/9 but if you think we should change it, please let me know