### PR TITLE
Add GCEState.get_ssh_host_keys

### DIFF
--- a/nixops_gcp/backends/gce.py
+++ b/nixops_gcp/backends/gce.py
@@ -207,6 +207,19 @@ class GCEState(MachineState[GCEDefinition], ResourceState):
             "items": [{"key": k, "value": v} for k, v in metadata.items()],
         }
 
+    # invoked by nixops before calling ssh
+    def get_ssh_host_keys(self):
+        return (
+            self.private_ipv4
+            + " "
+            + self.public_host_key
+            + "\n"
+            + self.public_ipv4
+            + " "
+            + self.public_host_key
+            + "\n"
+        )
+
     def update_block_device_mapping(self, k, v):
         x = self.block_device_mapping
         if v == None:


### PR DESCRIPTION
This will let NixOps provide the host keys directly to the ssh
client, regardless of whether they've been saved to user dotfiles.

It solves a problem where the host keys were not known on systems
that retrieve the state from a remote state provider.

See https://github.com/NixOS/nixops/pull/1464

I haven't tested this yet. It can be tested by removing entries from `~/.ssh/known_hosts` and then calling `nixops ssh`. It should still recognize the host key, as it is stored in the nixops state.